### PR TITLE
Drop trailing slashes from cdn.simpleicons.org resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Scripting for 8 hours to automate a one-time 8 minute task <img src="https://med
 -->
 
 ## Tools
-[<img src="https://cdn.simpleicons.org/vscodium/" height="40" width="40" />](https://vscodium.com/)
-[<img src="https://cdn.simpleicons.org/brave/" height="40" width="40" />](https://brave.com/)
-[<img src="https://cdn.simpleicons.org/stackoverflow/" height="40" width="40" />](https://stackoverflow.com/)
+[<img src="https://cdn.simpleicons.org/vscodium" height="40" width="40" />](https://vscodium.com/)
+[<img src="https://cdn.simpleicons.org/brave" height="40" width="40" />](https://brave.com/)
+[<img src="https://cdn.simpleicons.org/stackoverflow" height="40" width="40" />](https://stackoverflow.com/)
 
 <!--
-[<img src="https://cdn.simpleicons.org/telegram/" height="40" width="40" />](https://telegram.org/)
-[<img src="https://cdn.simpleicons.org/system76/" height="40" width="40" />](https://system76.com/)
-[<img src="https://cdn.simpleicons.org/bitcoin/" height="40" width="40" />](https://bitcoin.org/)
-[<img src="https://cdn.simpleicons.org/gimp/" height="40" width="40" />](https://gimp.org/)
+[<img src="https://cdn.simpleicons.org/telegram" height="40" width="40" />](https://telegram.org/)
+[<img src="https://cdn.simpleicons.org/system76" height="40" width="40" />](https://system76.com/)
+[<img src="https://cdn.simpleicons.org/bitcoin" height="40" width="40" />](https://bitcoin.org/)
+[<img src="https://cdn.simpleicons.org/gimp" height="40" width="40" />](https://gimp.org/)
 -->
 
 <!--


### PR DESCRIPTION
I decided not to implement the trailing slash support since URLs that end with slashes are not reasonable for image resources.